### PR TITLE
Basic Theme Support

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -296,7 +296,7 @@ function renderSuccess(state) {
         <p>Come back tomorrow!</p>
     `;
 
-    ok.innerHTML = "Ok";
+    ok.innerHTML = "OK";
 
     popup.append(content, ok);
 

--- a/src/main.js
+++ b/src/main.js
@@ -482,7 +482,7 @@ function showPopup(state) {
             `;
         } else {
             content.innerHTML = `
-                <p>Welcome back, you're at level ${state.level+1}.</p>
+                <p>Welcome back. You're at level ${state.level+1}.</p>
                 ${state.streak > 0 ? `<p>Your streak is currently ${state.streak}.</p>` : ''}
                 <p>Good luck!</p>
             `;

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,8 @@ import dictFile from './dictionary.txt';
 
 import { compareWords, isLetter } from './words.mjs';
 
+import { ThemeManager } from './theme.js';
+
 const loadFile = (file) => fetch(file).then((response) => response.text()).then((text) => text.split('\n'));
 
 const key = () => new Date().toLocaleDateString("en-CA");
@@ -116,7 +118,7 @@ function renderBoard(state) {
     const startWord = state.words[0];
     const endWord = state.words[5];
     const board = document.getElementById('board')
-        
+
     board.innerHTML = '';
 
     const words = flipped ? [...state.words].reverse() : state.words;
@@ -272,7 +274,7 @@ function handleBackspace(state) {
 function handleLetterInput(state, letter) {
     if (state.position.x < 5 && state.position.y > 0 && state.position.y < 5) {
         state.words[state.position.y][state.position.x] = letter;
-        
+
         state.position.x = state.position.x + 1;
     }
 }
@@ -548,6 +550,9 @@ async function main() {
     const pairs = await loadFile(pairsFile);
     const dict = await loadFile(dictFile);
     const state = init(parse(pairs), dict);
+
+    const themeManager = new ThemeManager();
+    window.themeManager = themeManager;
 
     render(state);
 

--- a/src/main.js
+++ b/src/main.js
@@ -284,7 +284,7 @@ function renderSuccess(state) {
     const app = document.getElementById('app');
     const popup = document.createElement('div');
 
-    popup.className = "success";
+    popup.className = "popup success";
 
     const ok = document.createElement('button');
     const content = document.createElement('div');
@@ -453,7 +453,7 @@ function showError(message) {
     const app = document.getElementById('app');
     const error = document.createElement('div');
 
-    error.className = 'error';
+    error.className = 'popup error';
     error.innerHTML = message;
 
     app.append(error);

--- a/src/style.css
+++ b/src/style.css
@@ -1,10 +1,96 @@
 /* Opinionated CSS defaults based on:
-  ! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css 
+  ! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css
 */
 
+:root, html[data-theme="light"] {
+  --background-color: white;
+  --text-color: black;
+  --border-color: #aaa;
+  --button-border-radius: 9px;
+  --button-background-color: #e5fce0;
+
+  --header-background-color: transparent;
+  --h1-color: var(--text-color);
+
+  --popup-top: 95px;
+  --popup-background-color: white;
+  --popup-border-color: var(--border-color);
+  --popup-color: black;
+  --popup-border-radius: 6px;
+
+  --letter-color: var(--text-color);
+  --letter-color-start: var(--letter-color);
+  --letter-color-end: var(--letter-color);
+
+  --letter-border-radius: 3px;
+
+  --letter-background-color: #f5f5f5;
+  --letter-background-color-start: #c0f8a8;
+  --letter-border-color-start: #7ab95e;
+  --letter-background-color-end: #81dbf3;
+  --letter-border-color-end: #4e8d9e;
+  --letter-background-color-active: #eee;
+
+  --letter-border-color-active: black;
+
+  --action-color: var(--text-color);
+  --action-background-color: var(--letter-background-color);
+  --action-border-color: var(--border-color);
+
+  --key-background-color: white;
+  --key-color: var(--text-color);
+  --key-border-color: var(--border-color);
+  --key-disabled-background-color: var(--key-background-color);
+  --key-disabled-color: lightgray;
+}
+
+[data-theme="classic"] {
+  --background-color: white;
+  --border-color: black;
+  --button-border-radius: 0;
+  --button-background-color: white;
+  --letter-border-radius: 0;
+  --letter-background-color: white;
+  --letter-background-color-active: var(--letter-background-color);
+  --letter-background-color-start: lightyellow;
+  --letter-background-color-end: lightcoral;
+  --letter-border-color-start: var(--border-color);
+  --letter-border-color-end: var(--border-color);
+  --popup-border-radius: 0;
+}
+
+html[data-theme="dark"] {
+  --background-color: #222;
+  --border-color: #aaa;
+  --text-color: white;
+
+  --header-background-color: #2a2a2a;
+  --h1-color: #bbb;
+
+  --button-background-color: #666;
+
+  --letter-background-color: #444;
+  --letter-box-shadow-start: 0 0 20px rgba(192, 248, 168, 0.3);
+  --letter-color-start: black;
+  --letter-color-end: black;
+  --letter-box-shadow-end: 0 0 20px rgba(129, 219, 243, 0.3);
+
+  --letter-border-color-active: white;
+  --letter-background-color-active: #777;
+
+  --popup-color: white;
+  --popup-background-color: #333;
+  --popup-border-color: #555;
+
+  --key-background-color: #555;
+  --key-color: var(--text-color);
+  --key-disabled-color: #666;
+  --key-disabled-background-color: #444;
+}
+
 html {
-  line-height: 1.2; 
-  -webkit-text-size-adjust: 100%; 
+  line-height: 1.2;
+  -webkit-text-size-adjust: 100%;
 }
 
 html, * {
@@ -13,22 +99,24 @@ html, * {
 
 body {
   margin: 0;
+  background-color: var(--background-color);
 }
 
 h1 {
   font-size: 2em;
   margin: 0.67em 0;
+  color: var(--h1-color);
 }
 
 hr {
-  box-sizing: content-box; 
-  height: 0; 
-  overflow: visible; 
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
 }
 
 pre {
-  font-family: monospace, monospace; 
-  font-size: 1em; 
+  font-family: monospace, monospace;
+  font-size: 1em;
 }
 
 b, strong {
@@ -36,7 +124,7 @@ b, strong {
 }
 
 code, kbd, samp {
-  font-family: monospace, monospace; 
+  font-family: monospace, monospace;
   font-size: 1em;
 }
 
@@ -60,13 +148,13 @@ sup {
 }
 
 button, input, optgroup, select, textarea {
-  font-family: inherit; 
-  font-size: 100%; 
-  line-height: 1.15; 
-  margin: 0; 
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
 }
 
-button, select { 
+button, select {
   text-transform: none;
 }
 
@@ -101,7 +189,7 @@ progress {
 
 [type="search"] {
   -webkit-appearance: textfield;
-  outline-offset: -2px; 
+  outline-offset: -2px;
 }
 
 [type="search"]::-webkit-search-decoration {
@@ -109,8 +197,8 @@ progress {
 }
 
 ::-webkit-file-upload-button {
-  -webkit-appearance: button; 
-  font: inherit; 
+  -webkit-appearance: button;
+  font: inherit;
 }
 
 [hidden] {
@@ -129,12 +217,15 @@ html, body, #app {
 #header {
   display: flex;
   align-items: center;
-  border-bottom: solid 1px black;
+  background-color: var(--header-background-color);
+  border-bottom: solid 1px var(--h1-color);
   padding: 10px;
+  margin-bottom: 10px;
 }
 
 #header h1 {
   flex: 1;
+  text-align: center;
   margin: 0;
 }
 
@@ -165,24 +256,35 @@ html, body, #app {
   display: flex;
   align-items: center;
   justify-content: center;
-  border: solid 1px black;
+  color: var(--letter-color);
+  border: solid 1px var(--border-color);
+  background-color: var(--letter-background-color);
+  border-radius: var(--letter-border-radius);
   height: 50px;
   width: 50px;
   font-size: 40px;
   text-transform: uppercase;
   box-sizing: border-box;
+  box-shadow: var(--letter-box-shadow);
 }
 
 .letter.start {
-  background-color: lightyellow;
+  background-color: var(--letter-background-color-start);
+  border-color: var(--letter-border-color-start);
+  color: var(--letter-color-start);
+  box-shadow: var(--letter-box-shadow-start);
 }
 
 .letter.end {
-  background-color: lightcoral;
+  background-color: var(--letter-background-color-end);
+  border-color: var(--letter-border-color-end);
+  color: var(--letter-color-end);
+  box-shadow: var(--letter-box-shadow-end);
 }
 
 .letter.active {
-  border: solid 2px black;
+  border: solid 2px var(--letter-border-color-active);
+  background-color: var(--letter-background-color-active);
 }
 
 #keyboard {
@@ -201,7 +303,10 @@ html, body, #app {
   display: flex;
   align-items: center;
   justify-content: center;
-  border: solid 1px black;
+  border: solid 1px var(--key-border-color);
+  border-radius: var(--letter-border-radius);
+  background-color: var(--key-background-color);
+  color: var(--key-color);
   height: 40px;
   width: 40px;
   font-size: 24px;
@@ -216,7 +321,9 @@ html, body, #app {
 }
 
 #keyboard .flip .key {
-  width: 90px;
+  width: 100px;
+  border-radius: var(--letter-border-radius);
+  font-size: 1.4rem;
 }
 
 #keyboard .control {
@@ -224,7 +331,8 @@ html, body, #app {
 }
 
 #keyboard .disabled {
-  color: lightgray;
+  background-color: var(--key-disabled-background-color);
+  color: var(--key-disabled-color);
   border: solid 1px lightgray;
 }
 
@@ -232,9 +340,61 @@ html, body, #app {
   margin-left: 10px;
 }
 
+.trash { 
+  position: absolute;
+  font-size: 30px;
+  cursor: pointer;
+}
+
+.enter, .backspace {
+  display: flex;
+  align-items: center;
+  background-color: var(--action-background-color);
+  justify-content: center;  position: absolute;
+  cursor: pointer;  
+  border: solid 1px var(--action-border-color);
+  color: var(--action-color);
+  height: 50px;
+  width: 50px;
+  font-size: 40px;
+  box-sizing: border-box;
+}
+
+.popup {
+  color: var(--popup-color);
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  top: var(--popup-top);
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: 300px;
+  padding: 10px;
+  border: solid 1px var(--popup-border-color);
+  border-radius: var(--popup-border-radius);
+  background-color: var(--popup-background-color);
+  text-align: center;
+  box-shadow: 1px 1px 10px rgba(0, 0, 0, 0.25);
+}
+
+.popup div, .success div {
+  flex: 1;
+}
+
+.popup button {
+  margin-top: 10px;
+  font-size: 18px;
+  text-transform: uppercase;
+  padding: 6px 0;
+  border: solid 1px var(--border-color);
+  border-radius: var(--button-border-radius);
+  background-color: var(--button-background-color);
+  cursor: pointer;
+}
+
 .error {
   position: fixed;
-  top: 75px;
+  top: var(--popup-top);
   left: 50%;
   transform: translate(-50%, 0);
   width: 300px;
@@ -250,7 +410,7 @@ html, body, #app {
   display: flex;
   flex-direction: column;
   position: fixed;
-  top: 75px;
+  top: var(--popup-top);
   left: 50%;
   transform: translate(-50%, 0);
   width: 300px;
@@ -262,46 +422,6 @@ html, body, #app {
   text-align: center;
 }
 
-.trash { 
-  position: absolute;
-  font-size: 30px;
-  cursor: pointer;
-}
-
-.enter, .backspace {
-  display: flex;
-  align-items: center;
-  justify-content: center;  position: absolute;
-  cursor: pointer;  
-  border: solid 1px black;
-  height: 50px;
-  width: 50px;
-  font-size: 40px;
-  box-sizing: border-box;
-}
-
-.popup {
-  position: fixed;
-  display: flex;
-  flex-direction: column;
-  top: 75px;
-  left: 50%;
-  transform: translate(-50%, 0);
-  width: 300px;
-  padding: 10px;
-  border: solid 1px black;
-  background-color: white;
-  text-align: center;
-}
-
-.popup div, .success div {
-  flex: 1;
-}
-
-.popup button {
-  margin-top: 10px;
-  font-size: 20px;
-}
 
 #stars {
   display: flex;

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,33 @@
+// vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+const DEFAULT_THEME = 'light';
+
+class ThemeManager {
+  constructor() {
+    this.theme = localStorage.getItem('theme');
+
+    if (this.theme === null) {
+        this.theme = (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+    }
+    this.setTheme(this.theme);
+  }
+
+  setTheme(theme) {
+      this.theme = theme;
+
+      if (theme) {
+          if (theme !== DEFAULT_THEME) {
+            localStorage.setItem('theme', theme);
+          }
+          document.documentElement.setAttribute('data-theme', theme);
+      } else {
+          localStorage.removeItem('theme');
+          document.documentElement.removeAttribute('data-theme');
+      }
+  }
+
+  clearTheme() {
+      this.setTheme(null);
+  }
+}
+
+export { ThemeManager }


### PR DESCRIPTION
* Start splitting out theme-able properties into CSS variables.
* Add themes for `light`, `dark`, and `classic`.
* Created a very basic theme manager to switch the theme and store the preference using `localStorage`.

```javascript
themeManager.setTheme('classic');
themeManager.clearTheme();
```

Note: if the OS is set to dark-mode, it will get detected on page load; however, if the mode is changed to dark mode after the page has loaded, it will not switch. CSS supports a media query which works great, but it seems to cause other issues with the way themes are added to the `documentElement`.

Example:

```css
@media (prefers-color-scheme: dark) {
  :root {
    --background-color: #444;
  }
}
```

Could periodically query things, but there surely is a better solution. To revisit at some point.

#### Light 
<img width="601" alt="image" src="https://user-images.githubusercontent.com/13967/215012520-3f655552-7598-4589-b262-637357c2b814.png">

#### Dark 
<img width="700" alt="image" src="https://user-images.githubusercontent.com/13967/215012560-f227f99c-022e-45dd-a821-f492ee8dec7b.png">

#### Classic
<img width="699" alt="image" src="https://user-images.githubusercontent.com/13967/215012606-211629d1-588d-46aa-b6cf-d588d18752c2.png">
